### PR TITLE
feat: multi-stream subscription (list of Redis streams)

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -19,7 +19,7 @@ jobs:
   python-validation:
     uses: stuttgart-things/github-workflow-templates/.github/workflows/call-python-validation.yaml@main
     with:
-      runs-on: dagger
+      runs-on: dagger-labul
       module-name: homerun2-led-catcher
       python-version: "3.12-slim"
       ruff-version: "0.8.6"
@@ -30,7 +30,7 @@ jobs:
 
   build-push-scan:
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: dagger
+    runs-on: dagger-labul
     needs: python-validation
     environment: k8s
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
-    runs-on: dagger
+    runs-on: dagger-labul
     environment: k8s
 
     steps:

--- a/src/led_catcher/__main__.py
+++ b/src/led_catcher/__main__.py
@@ -96,7 +96,7 @@ async def _run(cfg: Config) -> None:
         "configuration loaded",
         extra={
             "redis_addr": f"{cfg.redis.addr}:{cfg.redis.port}",
-            "stream": cfg.redis.stream,
+            "streams": cfg.redis.streams,
             "consumer_group": cfg.consumer_group,
         },
     )

--- a/src/led_catcher/config/settings.py
+++ b/src/led_catcher/config/settings.py
@@ -6,7 +6,7 @@ import logging
 import os
 import socket
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass
@@ -14,7 +14,12 @@ class RedisConfig:
     addr: str = "localhost"
     port: int = 6379
     password: str = ""
-    stream: str = "messages"
+    streams: list[str] = field(default_factory=lambda: ["messages"])
+
+    @property
+    def stream(self) -> str:
+        """Legacy single-stream accessor — returns the first configured stream."""
+        return self.streams[0] if self.streams else "messages"
 
 
 @dataclass
@@ -36,12 +41,32 @@ def _getenv(key: str, default: str = "") -> str:
     return os.environ.get(key, default)
 
 
+def parse_streams(streams_env: str, stream_fallback: str) -> list[str]:
+    """Resolve the list of Redis streams to subscribe to.
+
+    Precedence:
+      1. REDIS_STREAMS — comma-separated, whitespace-trimmed, empty entries dropped
+      2. REDIS_STREAM  — legacy single-stream env var, wrapped in a one-element list
+      3. ["messages"]  — hardcoded default
+
+    Legacy single-stream deployments keep working unchanged.
+    """
+    if streams_env:
+        parts = [p.strip() for p in streams_env.split(",")]
+        parts = [p for p in parts if p]
+        if parts:
+            return parts
+    if stream_fallback:
+        return [stream_fallback]
+    return ["messages"]
+
+
 def load_config() -> Config:
     redis_cfg = RedisConfig(
         addr=_getenv("REDIS_ADDR", "localhost"),
         port=int(_getenv("REDIS_PORT", "6379")),
         password=_getenv("REDIS_PASSWORD", ""),
-        stream=_getenv("REDIS_STREAM", "messages"),
+        streams=parse_streams(_getenv("REDIS_STREAMS", ""), _getenv("REDIS_STREAM", "")),
     )
 
     consumer_name = _getenv("CONSUMER_NAME", "")
@@ -106,6 +131,7 @@ class _JsonFormatter(logging.Formatter):
             "date",
             "redis_addr",
             "stream",
+            "streams",
             "consumer_group",
             "error",
             "object_id",

--- a/src/led_catcher/consumer/redis_consumer.py
+++ b/src/led_catcher/consumer/redis_consumer.py
@@ -45,16 +45,16 @@ class RedisConsumer:
         return self._client
 
     async def _ensure_group(self, client: aioredis.Redis) -> None:
-        stream = self._cfg.redis.stream
         group = self._cfg.consumer_group
-        try:
-            groups = await client.xinfo_groups(stream)
-            if not any(g["name"] == group for g in groups):
+        for stream in self._cfg.redis.streams:
+            try:
+                groups = await client.xinfo_groups(stream)
+                if not any(g["name"] == group for g in groups):
+                    await client.xgroup_create(stream, group, id="0", mkstream=True)
+                    logger.info("created consumer group %s on stream %s", group, stream)
+            except aioredis.ResponseError:
                 await client.xgroup_create(stream, group, id="0", mkstream=True)
-                logger.info("created consumer group %s on stream %s", group, stream)
-        except aioredis.ResponseError:
-            await client.xgroup_create(stream, group, id="0", mkstream=True)
-            logger.info("created consumer group %s on stream %s (new stream)", group, stream)
+                logger.info("created consumer group %s on stream %s (new stream)", group, stream)
 
     async def _resolve_payload(self, client: aioredis.Redis, message_id: str) -> Message | None:
         try:
@@ -76,13 +76,18 @@ class RedisConsumer:
         client = await self._connect()
         await self._ensure_group(client)
 
-        stream = self._cfg.redis.stream
+        streams = self._cfg.redis.streams
         group = self._cfg.consumer_group
         consumer = self._cfg.consumer_name
+        stream_ids = {s: ">" for s in streams}
 
         logger.info(
             "consumer starting",
-            extra={"redis_addr": self._cfg.redis.addr, "stream": stream, "consumer_group": group},
+            extra={
+                "redis_addr": self._cfg.redis.addr,
+                "streams": streams,
+                "consumer_group": group,
+            },
         )
 
         self._running = True
@@ -91,21 +96,21 @@ class RedisConsumer:
                 entries = await client.xreadgroup(
                     groupname=group,
                     consumername=consumer,
-                    streams={stream: ">"},
+                    streams=stream_ids,
                     count=10,
                     block=5000,
                 )
                 if not entries:
                     continue
 
-                for _stream_name, messages in entries:
+                for stream_name, messages in entries:
                     for entry_id, fields in messages:
-                        await self._process_entry(client, stream, group, entry_id, fields)
+                        await self._process_entry(client, stream_name, group, entry_id, fields)
 
             except asyncio.CancelledError:
                 break
             except Exception:
-                logger.exception("error reading from stream")
+                logger.exception("error reading from streams")
                 await asyncio.sleep(2)
 
     async def _process_entry(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,15 +1,18 @@
 """Tests for configuration loading."""
 
+import pytest
+
 from led_catcher.config import load_config
+from led_catcher.config.settings import parse_streams
 
 
-def test_load_config_defaults(monkeypatch):
-    # Clear relevant env vars
+def _clear_env(monkeypatch):
     for key in (
         "REDIS_ADDR",
         "REDIS_PORT",
         "REDIS_PASSWORD",
         "REDIS_STREAM",
+        "REDIS_STREAMS",
         "CONSUMER_GROUP",
         "LED_MODE",
         "HEALTH_PORT",
@@ -18,11 +21,16 @@ def test_load_config_defaults(monkeypatch):
     ):
         monkeypatch.delenv(key, raising=False)
 
+
+def test_load_config_defaults(monkeypatch):
+    _clear_env(monkeypatch)
+
     cfg = load_config()
     assert cfg.redis.addr == "localhost"
     assert cfg.redis.port == 6379
     assert cfg.redis.password == ""
-    assert cfg.redis.stream == "messages"
+    assert cfg.redis.streams == ["messages"]
+    assert cfg.redis.stream == "messages"  # legacy accessor
     assert cfg.consumer_group == "homerun2-led-catcher"
     assert cfg.led_mode == "full"
     assert cfg.health_port == 8080
@@ -30,7 +38,8 @@ def test_load_config_defaults(monkeypatch):
     assert cfg.log_level == "info"
 
 
-def test_load_config_custom(monkeypatch):
+def test_load_config_custom_legacy_single_stream(monkeypatch):
+    _clear_env(monkeypatch)
     monkeypatch.setenv("REDIS_ADDR", "redis.example.com")
     monkeypatch.setenv("REDIS_PORT", "6380")
     monkeypatch.setenv("REDIS_PASSWORD", "secret")
@@ -45,9 +54,37 @@ def test_load_config_custom(monkeypatch):
     assert cfg.redis.addr == "redis.example.com"
     assert cfg.redis.port == 6380
     assert cfg.redis.password == "secret"
+    assert cfg.redis.streams == ["events"]
     assert cfg.redis.stream == "events"
     assert cfg.consumer_group == "my-group"
     assert cfg.led_mode == "web"
     assert cfg.health_port == 9090
     assert cfg.log_format == "text"
     assert cfg.log_level == "debug"
+
+
+def test_load_config_multi_stream(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("REDIS_STREAMS", "homerun,releases")
+    # Legacy var is ignored when REDIS_STREAMS is set
+    monkeypatch.setenv("REDIS_STREAM", "ignored")
+
+    cfg = load_config()
+    assert cfg.redis.streams == ["homerun", "releases"]
+    assert cfg.redis.stream == "homerun"  # legacy accessor returns first
+
+
+@pytest.mark.parametrize(
+    "streams_env,stream_fallback,expected",
+    [
+        ("homerun,releases", "ignored", ["homerun", "releases"]),
+        (" homerun , releases ", "", ["homerun", "releases"]),
+        ("homerun,,releases,", "", ["homerun", "releases"]),
+        ("", "homerun", ["homerun"]),
+        ("", "messages", ["messages"]),
+        ("", "", ["messages"]),
+        (" , , ", "legacy", ["legacy"]),
+    ],
+)
+def test_parse_streams(streams_env, stream_fallback, expected):
+    assert parse_streams(streams_env, stream_fallback) == expected


### PR DESCRIPTION
## Summary
- Add \`REDIS_STREAMS\` (comma-separated) env var; the Redis consumer subscribes to every listed stream via a single \`XREADGROUP\` call and ACKs each entry against the stream it actually came from.
- Legacy \`REDIS_STREAM\` still honored and resolves to a one-element list — existing deployments behave identically.
- \`RedisConfig.stream\` preserved as a read-only legacy accessor (\`streams[0]\`), so any external code still works.
- \`_ensure_group\` now creates the consumer group on each configured stream at startup.
- Startup log emits the resolved list under \`streams\`.

Mirrors the Go-side change in stuttgart-things/homerun2-core-catcher#53.

## Resolution order

1. \`REDIS_STREAMS\` (comma-separated, whitespace-trimmed, empty entries dropped)
2. \`REDIS_STREAM\` (legacy single-stream env var)
3. \`[\"messages\"]\` hardcoded default

Closes #26
Refs stuttgart-things/homerun-library#83

## Test plan
- [x] \`pytest\` green (46 tests; new \`test_parse_streams\` parametrized cases + updated config tests for legacy-single and multi-stream paths)
- [x] \`ruff check\` + \`ruff format --check\` clean
- [ ] CI: dagger python-validation
- [ ] Manual: run with \`REDIS_STREAMS=homerun,releases\` and confirm startup log shows both; verify unset \`REDIS_STREAMS\` still subscribes to \`REDIS_STREAM\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)