### PR TITLE
ci(preview): add PR-preview workflow set

### DIFF
--- a/.github/workflows/build-scan-image.yaml
+++ b/.github/workflows/build-scan-image.yaml
@@ -1,0 +1,56 @@
+---
+name: Build, Push & Scan Container Image
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-pr:
+    if: github.event_name == 'pull_request'
+    runs-on: dagger-labul
+    environment: k8s
+    outputs:
+      image-ref: ${{ steps.push.outputs.image-ref }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Login to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build and push image to GHCR
+        id: push
+        run: |
+          IMAGE="ghcr.io/${{ github.repository }}"
+          SHA_TAG="pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}"
+          NUM_TAG="pr-${{ github.event.number }}"
+          docker build \
+            --build-arg VERSION=${SHA_TAG} \
+            --build-arg COMMIT=${{ github.event.pull_request.head.sha }} \
+            --build-arg DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+            -t ${IMAGE}:${SHA_TAG} \
+            -t ${IMAGE}:${NUM_TAG} \
+            .
+          docker push ${IMAGE}:${SHA_TAG}
+          docker push ${IMAGE}:${NUM_TAG}
+          echo "image-ref=${IMAGE}:${SHA_TAG}" >> "$GITHUB_OUTPUT"
+
+  trivy-scan:
+    if: github.event_name == 'pull_request'
+    needs: build-pr
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-dagger-trivy-image-scan.yaml@main
+    with:
+      runs-on: dagger-labul
+      image-ref: ${{ needs.build-pr.outputs.image-ref }}
+      continue-on-error: true
+    secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -27,38 +27,3 @@ jobs:
       accept-linterrors: false
       accept-failedtests: false
     secrets: inherit
-
-  build-push-scan:
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: dagger-labul
-    needs: python-validation
-    environment: k8s
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6.0.2
-
-      - name: Build and push Docker image to ttl.sh
-        uses: dagger/dagger-for-github@v8.4.0
-        with:
-          version: "0.20.0"
-          verb: call
-          module: github.com/stuttgart-things/dagger/docker@v0.86.0
-          args: >-
-            build
-            --src .
-            push
-            --repository-name stuttgart-things/homerun2-led-catcher
-            --registry-url ttl.sh
-            --tag 1h
-
-      - name: Trivy scan pushed image
-        uses: dagger/dagger-for-github@v8.4.0
-        with:
-          version: "0.20.0"
-          verb: call
-          module: github.com/stuttgart-things/dagger/trivy@v0.86.0
-          args: >-
-            scan-image
-            --image-ref ttl.sh/stuttgart-things/homerun2-led-catcher:1h
-            export --path /tmp/trivy-report.json
-        continue-on-error: true

--- a/.github/workflows/cleanup-pr-artifacts.yaml
+++ b/.github/workflows/cleanup-pr-artifacts.yaml
@@ -1,0 +1,16 @@
+---
+name: Cleanup PR Artifacts
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  cleanup:
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-cleanup-pr-artifacts.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      packages: homerun2-led-catcher,homerun2-led-catcher-kustomize
+      dry-run: false
+    secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/comment-preview-url.yaml
+++ b/.github/workflows/comment-preview-url.yaml
@@ -1,0 +1,16 @@
+---
+name: Comment Preview URL on PR
+on:
+  pull_request:
+    types: [opened, reopened]
+    branches:
+      - main
+
+jobs:
+  comment:
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-comment-preview-url.yaml@main
+    with:
+      hostname-prefix: led-pr
+      hostname-domain: homerun2-dev.sthings-vsphere.labul.sva.de
+      namespace-prefix: homerun2-led-catcher-pr
+    secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/push-kustomize-pr.yaml
+++ b/.github/workflows/push-kustomize-pr.yaml
@@ -1,0 +1,21 @@
+---
+name: Push PR Kustomize OCI
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  push-kustomize:
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-push-kustomize.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      kcl-source-dir: kcl
+      kcl-profile-file: tests/kcl-deploy-profile.yaml
+      kustomize-oci-repo: ghcr.io/stuttgart-things/homerun2-led-catcher-kustomize
+      tag: pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}
+    secrets: inherit # pragma: allowlist secret

--- a/tests/kcl-deploy-profile.yaml
+++ b/tests/kcl-deploy-profile.yaml
@@ -6,3 +6,12 @@ config.redisStream: messages
 config.consumerGroup: homerun2-led-catcher
 config.ledMode: web
 config.healthPort: "8080"
+# HTTPRoute lives in the same kustomize apply as the Service so they land
+# atomically — avoids the Cilium gateway controller caching BackendNotFound
+# when the HTTPRoute is created before its Service (stuttgart-things/argocd#116).
+# Consumers without a Gateway API can drop the HTTPRoute via a kustomize delete
+# patch; the homerun2-install chart patches the parentRef + hostname per env.
+config.httpRouteEnabled: true
+config.httpRouteParentRefName: homerun2-dev-gateway
+config.httpRouteParentRefNamespace: default
+config.httpRouteHostname: homerun2-led-catcher.example.com


### PR DESCRIPTION
## Summary

Fifth-component rollout of the per-PR preview pattern (umbrella: stuttgart-things/homerun2-omni-pitcher#116, Step 3). Mirrors the workflow set shipped by `homerun2-omni-pitcher` (pilot), `homerun2-core-catcher` (first transplant) and `homerun2-scout` (second transplant) — same reusable callers, same artifact tag scheme (`pr-<num>-<sha>`), same bot-comment pattern via [`call-comment-preview-url.yaml`](https://github.com/stuttgart-things/github-workflow-templates/blob/main/.github/workflows/call-comment-preview-url.yaml).

| Workflow | Purpose |
|---|---|
| `build-scan-image.yaml` | new — PR build pushes `ghcr.io/stuttgart-things/homerun2-led-catcher:pr-<num>-<sha>` (+ moving `pr-<num>` tag) via direct `docker build/push` (Python project, no ko); trivy scan via reusable |
| `push-kustomize-pr.yaml` | new — pushes matching kustomize OCI to `ghcr.io/stuttgart-things/homerun2-led-catcher-kustomize:pr-<num>-<sha>` |
| `cleanup-pr-artifacts.yaml` | new — deletes both packages' `pr-<num>-*` versions on PR close (`dry-run: false`) |
| `comment-preview-url.yaml` | new — sticky bot comment: URL `led-pr-<num>.homerun2-dev.sthings-vsphere.labul.sva.de`, namespace `homerun2-led-catcher-pr-<num>`, ArgoCD link |
| `build-test.yaml` | trimmed — drop the ttl.sh `build-push-scan` job (subsumed by `build-scan-image.yaml`); keeps the `python-validation` reusable call |
| `tests/kcl-deploy-profile.yaml` | flip **Option B** — `config.httpRouteEnabled: true` so HTTPRoute ships in the kustomize OCI atomically with Service (fixes the Cilium gateway `BackendNotFound` cache race per stuttgart-things/argocd#116) |

## Decisions (per #116)

- **Namespace**: `homerun2-led-catcher-pr-<num>` (image-name-mirrored)
- **Hostname**: `led-pr-<num>.homerun2-dev.sthings-vsphere.labul.sva.de`
- **Build tool**: direct `docker build/push` to GHCR (Python project — no ko equivalent in the templates repo)

## Cluster-side wiring (separate stuttgart-things PR)

After this lands, a stuttgart-things PR will add:

- `led-pr-preview-appset.yaml` — AppSet with PR generator pointed at this repo (PAT-gated, `labels: [preview]`)
- 4 new policy Applications (`homerun2-led-catcher-preview-{quota,secrets,seed-data,sweep}.yaml`) — same catalog charts as scout's, scoped to `homerun2-led-catcher-pr-*`

## Test plan

- [x] All 5 workflow files YAML-valid; image/kustomize paths point at `homerun2-led-catcher` + `homerun2-led-catcher-kustomize`
- [x] Bot caller inputs (`led-pr`, `homerun2-led-catcher-pr`) match the planned cluster-overlay AppSet
- [x] KCL profile renders HTTPRoute (Option B) — Service + HTTPRoute apply atomically in the same kustomize OCI
- [ ] After merge + cluster-side PR: open a no-op PR with the `preview` label → bot comments → CI publishes both artifacts → AppSet picks up → preview env spins up

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)