### PR TITLE
docs: refresh CI pipeline diagram for PR-preview env

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,8 +224,12 @@ Pre-commit (git hook)
 │     Lint, Format-Check, Test, Security-Scan
 │     Local: task ci
 │
-├─► Pull Request (Stage 2: build-test.yaml)
-│     Stage 1 + Docker build → push ttl.sh → Trivy scan
+├─► Pull Request (Stage 2: build-scan-image.yaml + push-kustomize-pr.yaml)
+│     Docker build → push GHCR `pr-<num>-<sha>` → Trivy scan
+│     Kustomize OCI → push GHCR `<repo>-kustomize:pr-<num>-<sha>`
+│     ArgoCD AppSet spins up a preview env at
+│     `led-pr-<num>.homerun2-dev.sthings-vsphere.labul.sva.de`
+│     (add the `preview` label to the PR to opt in)
 │     Local: task ci-pr
 │
 ├─► Merge to main (Stage 3: release.yaml)


### PR DESCRIPTION
## Summary

Tiny README fix — Stage 2 of the CI pipeline diagram was stale after #32 merged. Updates it to describe the new workflow set (`build-scan-image.yaml` + `push-kustomize-pr.yaml` pushing to GHCR with `pr-<num>-<sha>` tags) and the cluster-side AppSet that materialises a preview env at `led-pr-<num>.homerun2-dev....`.

Doubles as a **smoke test** for the end-to-end PR-preview chain now that both prerequisites have merged:
- Repo side: #32 (workflows + Option B KCL flip)
- Cluster side: stuttgart-things/argocd#148 (AppSet + 4 policy rows)

## Test plan

- [ ] Add `preview` label to this PR → AppSet opts in
- [ ] `build-scan-image.yaml` publishes `ghcr.io/stuttgart-things/homerun2-led-catcher:pr-<num>-<sha>`
- [ ] `push-kustomize-pr.yaml` publishes `ghcr.io/stuttgart-things/homerun2-led-catcher-kustomize:pr-<num>-<sha>`
- [ ] `comment-preview-url.yaml` posts the sticky bot comment
- [ ] ArgoCD parent Application `homerun2-led-catcher-pr-<num>` Synced/Healthy
- [ ] Kyverno generates per-namespace ResourceQuota / LimitRange / 4 ExternalSecrets / seed Job
- [ ] led-catcher pod boots clean; web simulator reachable at the preview URL; seed events render
- [ ] Close PR → workload prune + GHCR cleanup wipes `pr-<num>-*` artifacts

Refs stuttgart-things/homerun2-omni-pitcher#116

🤖 Generated with [Claude Code](https://claude.com/claude-code)