### PR TITLE
fix(kcl): always wire REDIS_PASSWORD env via secretKeyRef

### DIFF
--- a/kcl/deploy.k
+++ b/kcl/deploy.k
@@ -53,16 +53,23 @@ deployment = {
                                 name: "REDIS_PORT"
                                 value: str(config.redisPort)
                             }
-                            if config.redisPassword:
-                                {
-                                    name: "REDIS_PASSWORD"
-                                    valueFrom: {
-                                        secretKeyRef: {
-                                            name: "{}-redis".format(config.name)
-                                            key: "password"
-                                        }
+                            {
+                                # Always reference the Secret via secretKeyRef so
+                                # out-of-band Secret providers (ESO in per-PR
+                                # preview namespaces) populate REDIS_PASSWORD
+                                # without rebuilding the kustomize OCI. optional:
+                                # True lets the pod start when the Secret is
+                                # absent (Redis without auth) — the client then
+                                # connects unauthenticated.
+                                name: "REDIS_PASSWORD"
+                                valueFrom: {
+                                    secretKeyRef: {
+                                        name: "{}-redis".format(config.name)
+                                        key: "password"
+                                        optional: True
                                     }
                                 }
+                            }
                             {
                                 name: "REDIS_STREAM"
                                 value: config.redisStream


### PR DESCRIPTION
## Summary

`kcl/deploy.k` previously only emitted the `REDIS_PASSWORD` env var when `config.redisPassword` was set **at KCL render time** (baked into the kustomize OCI). In per-PR preview namespaces the Vault → ESO machinery creates the `homerun2-led-catcher-redis` Secret out-of-band, after the OCI is built — the Deployment never referenced it, so the consumer connected to an auth-required Redis without credentials and silently failed every `XREADGROUP`.

Verified live on #33's preview env: `XLEN messages` returned `NOAUTH` from inside the cluster, led-catcher logs stopped at `configuration loaded` with zero consumer activity for 2h+. A temporary `kubectl patch` adding the env var (via `secretKeyRef` on `homerun2-led-catcher-redis`) drained the entire backlog within seconds.

## Fix

Render the env var unconditionally with `optional: True` so all three shapes work:

| Scenario | Behaviour |
|---|---|
| Production (KCL renders the Secret too) | Inline literal — same as today |
| Preview (ESO creates the Secret out-of-band) | ESO-managed value — fixes the bug |
| No Secret at all (Redis without auth) | Pod starts, client connects unauthenticated |

## Test plan

- [x] `kcl run kcl/` renders the env var with `secretKeyRef` + `optional: true`
- [x] `task lint` + `task format-check` pass (pytest not in local PATH; CI will run it)
- [ ] After merge: next semantic-release publishes a new versioned kustomize OCI; bump pin in `stuttgart-things/argocd@platforms/homerun2-pr-preview/appset-led-catcher-pr-preview.yaml` to consume the fix
- [ ] Open a fresh PR with the `preview` label and confirm events flow through to the web simulator

## Refs

Closes #34
Refs stuttgart-things/homerun2-omni-pitcher#116
Validated on smoke env: #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)