### PR TITLE
ci(preview): post URL comment when `preview` label is added later

### DIFF
--- a/.github/workflows/comment-preview-url.yaml
+++ b/.github/workflows/comment-preview-url.yaml
@@ -2,12 +2,24 @@
 name: Comment Preview URL on PR
 on:
   pull_request:
-    types: [opened, reopened]
+    # Note: deliberately no `opened`. When a PR is created with `preview`
+    # already attached, GitHub fires both `opened` and `labeled` events
+    # back-to-back, and the comment template can't dedupe across two
+    # near-simultaneous runs — you end up with two URL comments. The
+    # `labeled` event handles the at-creation case just fine on its own.
+    types: [reopened, labeled]
     branches:
       - main
 
 jobs:
   comment:
+    # `labeled`: post only when the just-added label is `preview` (the
+    # label the AppSet keys on). `reopened`: post only if the PR still
+    # has the `preview` label attached — `reopened` doesn't fire a
+    # `labeled` event, so we have to check the current label set.
+    if: |
+      (github.event.action == 'labeled' && github.event.label.name == 'preview') ||
+      (github.event.action == 'reopened' && contains(github.event.pull_request.labels.*.name, 'preview'))
     uses: stuttgart-things/github-workflow-templates/.github/workflows/call-comment-preview-url.yaml@main
     with:
       hostname-prefix: led-pr


### PR DESCRIPTION
## Summary

Mirrors [stuttgart-things/machinery#59](https://github.com/stuttgart-things/machinery/pull/59). The previous trigger (`opened, reopened`) didn't react to labelling, so PRs that were opened without the `preview` label and labelled afterwards never got the URL comment — even though the preview env was deployed.

## Changes

- `types: [opened, reopened]` → `types: [reopened, labeled]`
- Job-level `if` guard so we only post when:
  - the just-added label is `preview` (on `labeled`), or
  - the PR still has `preview` attached (on `reopened`)
- `opened` dropped on purpose: when a PR is created with `preview` already attached, GitHub fires both `opened` and `labeled` ~1s apart and the comment template can't dedupe across two near-simultaneous runs — you'd get two URL comments. `labeled` covers the at-creation case fine on its own.

## Why now

Hit this on #29 (the python `3.12-slim` → `3.14-slim` Renovate PR): labelled `preview` after rebasing, env will be deployed, but no URL comment posts back. Same problem #59 fixed for machinery.

## Test plan

This PR is opened with `preview` already set, which exercises the `labeled` path. If the URL comment posts (once, not twice), the fix works as intended.

- [ ] Single URL comment appears on this PR.
- [ ] After merge: re-label PR #29 (remove + re-add `preview`) — confirm URL comment posts there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)