### PR TITLE
docs: add homerun2-notification-catcher to Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ All CI uses reusable Dagger modules from [`stuttgart-things/dagger`](https://git
 | [homerun2-core-catcher](https://github.com/stuttgart-things/homerun2-core-catcher) | Core consumer — log/CLI/web display modes |
 | [homerun2-light-catcher](https://github.com/stuttgart-things/homerun2-light-catcher) | WLED light consumer — triggers LED strip effects |
 | [homerun2-git-pitcher](https://github.com/stuttgart-things/homerun2-git-pitcher) | GitHub watcher — polls GitHub API for events and pitches them to Redis Streams |
+| [homerun2-notification-catcher](https://github.com/stuttgart-things/homerun2-notification-catcher) | Notification consumer — routes messages to MS Teams / webhooks via YAML-configured filters |
 | [homerun-library](https://github.com/stuttgart-things/homerun-library) | Shared Go library for message types and Redis ops |
 
 ## License


### PR DESCRIPTION
## Summary
The notification-catcher (MS Teams / webhook consumer for the `homerun.Message` stream) joined the homerun2 lineup but never made it into this README's Related Projects list. Slotting it in next to the other catchers/pitchers.

## Note for reviewers
This PR also doubles as the verification trigger for a `teams-git-prs` route just added to the platform-sthings notification-catcher overlay — opening it should produce a `dry-run: would send","output":"teams-git-prs"` line in `kubectl logs deploy/homerun2-notification-catcher -n homerun2` within ~5 minutes (the git-pitcher's poll interval). Once that's seen, the dry-run flag flips off in stuttgart-things/stuttgart-things#2229 and real Teams posts begin. Merging the doc change itself is fine, but no rush.

🤖 Generated with [Claude Code](https://claude.com/claude-code)